### PR TITLE
Fix wrong unit in error message

### DIFF
--- a/python/src/errors/query_run_errors.py
+++ b/python/src/errors/query_run_errors.py
@@ -18,11 +18,11 @@ class QueryRunTimeoutError(BaseError):
     Base class for all QueryRunTimeoutError errors.
     """
 
-    def __init__(self, timeoutMinutes: Union[int, float, None] = None):
-        if timeoutMinutes is None:
+    def __init__(self, timeoutSeconds: Union[int, float, None] = None):
+        if timeoutSeconds is None:
             self.message = f"QUERY_RUN_TIMEOUT_ERROR: your query has timed out."
         else:
-            self.message = f"QUERY_RUN_TIMEOUT_ERROR: your query has timed out after {timeoutMinutes} minutes."
+            self.message = f"QUERY_RUN_TIMEOUT_ERROR: your query has timed out after {timeoutSeconds} seconds."
         super().__init__(self.message)
 
 


### PR DESCRIPTION
The query timeout error is thrown with a second duration but the current error definition expects minutes.
This PR changes the error to show a duration in seconds

https://github.com/FlipsideCrypto/sdk/blob/main/python/src/integrations/query_integration/compass_query_integration.py#L267